### PR TITLE
Correction for PR#5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ You can ignore this section if you are working with the standard RGBDigit module
 
 If you have made your own RGBDigit then you can use this section to set the library up for your digit.
 
-####Segments per digit
+#### Segments per digit
 The standard 7-segment display has 8 segments (7 for the digit and a decimal point).  If your display has only the 7 (ie no decimal point) then you need to call the constructor specifying that there are 7 segments per digit as opposed to the default 8.
 
 `RGBDigit rgbDigit(nDigits, 6);` in the examples becomes `RGBDigit rgbDigit(nDigits, 6, NEO_GRB + NEO_KHZ800, 7);`
 
-####Choice of NeoPixel type
-The standard RGBDigit module uses the type `` but if you've made your own this might be different.  This may cause incorrect colours to display for example.  You can set the type of NeoPixel to use in the constructor:
+#### Choice of NeoPixel type
+The standard RGBDigit module uses the type `NEO_GRB + NEO_KHZ800` but if you've made your own this might be different.  This may cause incorrect colours to display for example.  You can set the type of NeoPixel to use in the constructor:
 
 `RGBDigit rgbDigit(nDigits, 6);` in the examples becomes `RGBDigit rgbDigit(nDigits, 6, NEO_GRB + NEO_KHZ800);` (simply use the appropriate definition from the documentation of the Arduino_NeoPixel library.  If the option is omitted it defaults to `NEO_GRB + NEO_KHZ800`.
 
@@ -52,62 +52,62 @@ Where `segmentsPerDigit` is set to `7` the *segment* parameters can be values fr
     4     2
        3
 
-#####```RGBDigit(int nDigits, int pin = 12, neoPixelType t=NEO_GRB + NEO_KHZ800, int segmentsPerDigit = 8);```
+##### ```RGBDigit(int nDigits, int pin = 12, neoPixelType t=NEO_GRB + NEO_KHZ800, int segmentsPerDigit = 8);```
 
 The constructor of the RGBDigit class. *nDigits* is the number of digits. *pin* is the pin number, which defaults to pin 12 if this parameter is omitted.  Provision is made to change the type of NeoPixel using the types defined in the Adafruit_NeoPixel library.  This defaults to `NEO_GRB + NEO_KHZ800` the type used in the RGBDigit.  Further more the option is given to set the number of segments per digit to 7 or 8 depending on whether a decimal point is present on the display (see above for details).
 
-#####```void begin();```
+##### ```void begin();```
 
 Initialises the RGBDigit.
 
-#####```void clearAll();```
+##### ```void clearAll();```
 
 Clear all digits.
 
-#####```void setDigit(int number, int digit, byte red, byte green, byte blue);```
+##### ```void setDigit(int number, int digit, byte red, byte green, byte blue);```
 
 Show *number* (from 0 - 9) on *digit* in color rgb(*red*,*green*,*blue*).
 
-#####```void setDigit(char character, int digit, byte red, byte green, byte blue);```
+##### ```void setDigit(char character, int digit, byte red, byte green, byte blue);```
 
 Show *character* on *digit* in color rgb(*red*,*green*,*blue*). Valid characters are letters (case insensitive) from *a* to *z*, the dot (*.*), dash (*-*), underscore (*_*), brackets ( *( ) { } [ ]* ) and space . Use an asterisk (*) for the degree sign.
 
-#####```void clearDigit(int digit);```
+##### ```void clearDigit(int digit);```
 
 Clear *digit*.
 
-#####```void showDot(int digit, byte red, byte green, byte blue);```
+##### ```void showDot(int digit, byte red, byte green, byte blue);```
 
 Show dot on *digit* in color rgb(*red*,*green*,*blue*). This does nothing when `segmentsPerDigit` is set to `7`.
 
-#####```void clearDot(int digit);```
+##### ```void clearDot(int digit);```
 
 Clear dot on *digit*. This does nothing when `segmentsPerDigit` is set to `7`.
 
-#####```void segmentOn(int digit, byte segment, byte red, byte green, byte blue);```
+##### ```void segmentOn(int digit, byte segment, byte red, byte green, byte blue);```
 
 Show *segment* on *digit* in color rgb(*red*,*green*,*blue*).
 
-#####```void segmentOff(int digit, byte segment);```
+##### ```void segmentOff(int digit, byte segment);```
 
 Clear *segment* on *digit*.
 
-#####```bool isSegmentOn(int digit, byte segment);```
+##### ```bool isSegmentOn(int digit, byte segment);```
 
 Returns True if *segment* on *digit* is on. Otherwise, returns False.
 
-#####```void setColor(byte red, byte green, byte blue);```
+##### ```void setColor(byte red, byte green, byte blue);```
 
 Set the color of all digits to color rgb(*red*,*green*,*blue*).
 
-#####```void setColor(int digit, byte red, byte green, byte blue);```
+##### ```void setColor(int digit, byte red, byte green, byte blue);```
 
 Set the color of *digit* to color rgb(*red*,*green*,*blue*).
 
-#####```void setBrightness(byte brightness);```
+##### ```void setBrightness(byte brightness);```
 
 Set the *brightness* of the strip to a value from 0 to 255.
 
-#####```byte getBrightness();```
+##### ```byte getBrightness();```
 
 Returns the brightness of the strip.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,9 @@ You can ignore this section if you are working with the standard RGBDigit module
 If you have made your own RGBDigit then you can use this section to set the library up for your digit.
 
 ####Segments per digit
-The standard 7-segment display has 8 segments (7 for the digit and a decimal point).  If your display has only the 7 (ie no decimal point) then add
+The standard 7-segment display has 8 segments (7 for the digit and a decimal point).  If your display has only the 7 (ie no decimal point) then you need to call the constructor specifying that there are 7 segments per digit as opposed to the default 8.
 
-`#define RGBDIGIT_SEGS_PER_DIGIT 7`
-
-to your sketch *before* calling the library.
+`RGBDigit rgbDigit(nDigits, 6);` in the examples becomes `RGBDigit rgbDigit(nDigits, 6, NEO_GRB + NEO_KHZ800, 7);`
 
 ####Choice of NeoPixel type
 The standard RGBDigit module uses the type `` but if you've made your own this might be different.  This may cause incorrect colours to display for example.  You can set the type of NeoPixel to use in the constructor:
@@ -38,7 +36,7 @@ The standard RGBDigit module uses the type `` but if you've made your own this m
 ## Class methods
 Note that for all *digit* parameters, the first digit has index 0, the second digit has index 1, etc.
 
-Where `RGBDIGIT_SEGS_PER_DIGIT` is not defined or is set to `8`; the *segment* parameters can be values from 0 to 7, every number corresponding to the following positions:
+Where `segmentsPerDigit` is not specified in the constructor call, or is set to `8`; the *segment* parameters can be values from 0 to 7, every number corresponding to the following positions:
 
        0
     5     1
@@ -46,7 +44,7 @@ Where `RGBDIGIT_SEGS_PER_DIGIT` is not defined or is set to `8`; the *segment* p
     4     2
        3      7
 
-Where `RGBDIGIT_SEGS_PER_DIGIT` is defined and set to `7` the *segment* parameters can be values from 0 to 6 (no decimal point) and correspond to the following positions:
+Where `segmentsPerDigit` is set to `7` the *segment* parameters can be values from 0 to 6 (no decimal point) and correspond to the following positions:
 
        0
     5     1
@@ -54,9 +52,9 @@ Where `RGBDIGIT_SEGS_PER_DIGIT` is defined and set to `7` the *segment* paramete
     4     2
        3
 
-#####```RGBDigit(int nDigits, int pin = 12, neoPixelType t=NEO_GRB + NEO_KHZ800);```
+#####```RGBDigit(int nDigits, int pin = 12, neoPixelType t=NEO_GRB + NEO_KHZ800, int segmentsPerDigit = 8);```
 
-The constructor of the RGBDigit class. *nDigits* is the number of digits. *pin* is the pin number, which defaults to pin 12 if this parameter is omitted.  Provision is made to change the type of NeoPixel using the types defined in the Adafruit_NeoPixel library.  This defaults to `NEO_GRB + NEO_KHZ800` the type used in the RGBDigit.
+The constructor of the RGBDigit class. *nDigits* is the number of digits. *pin* is the pin number, which defaults to pin 12 if this parameter is omitted.  Provision is made to change the type of NeoPixel using the types defined in the Adafruit_NeoPixel library.  This defaults to `NEO_GRB + NEO_KHZ800` the type used in the RGBDigit.  Further more the option is given to set the number of segments per digit to 7 or 8 depending on whether a decimal point is present on the display (see above for details).
 
 #####```void begin();```
 
@@ -80,15 +78,15 @@ Clear *digit*.
 
 #####```void showDot(int digit, byte red, byte green, byte blue);```
 
-Show dot on *digit* in color rgb(*red*,*green*,*blue*). This does nothing when `RGBDIGIT_SEGS_PER_DIGIT` is set to 7.
+Show dot on *digit* in color rgb(*red*,*green*,*blue*). This does nothing when `segmentsPerDigit` is set to `7`.
 
 #####```void clearDot(int digit);```
 
-Clear dot on *digit*. .
+Clear dot on *digit*. This does nothing when `segmentsPerDigit` is set to `7`.
 
 #####```void segmentOn(int digit, byte segment, byte red, byte green, byte blue);```
 
-Show *segment* on *digit* in color rgb(*red*,*green*,*blue*). This does nothing when `RGBDIGIT_SEGS_PER_DIGIT` is set to 7.
+Show *segment* on *digit* in color rgb(*red*,*green*,*blue*).
 
 #####```void segmentOff(int digit, byte segment);```
 

--- a/RGBDigit.cpp
+++ b/RGBDigit.cpp
@@ -18,13 +18,13 @@
 
 #include "RGBDigit.h"
 
-RGBDigit::RGBDigit(int nDigits, int pin, neoPixelType t)
-  : Adafruit_NeoPixel(RGBDIGIT_SEGS_PER_DIGIT * nDigits, pin, t),
-  _brightness(32), _nDigits(nDigits)
+RGBDigit::RGBDigit(int nDigits, int pin, neoPixelType t, int segmentsPerDigit)
+  : Adafruit_NeoPixel(segmentsPerDigit * nDigits, pin, t),
+  _brightness(32), _nDigits(nDigits), _segmentsPerDigit(segmentsPerDigit)
 {
-  _rArray = new byte[RGBDIGIT_SEGS_PER_DIGIT * nDigits]; // to store red values of each LED
-  _gArray = new byte[RGBDIGIT_SEGS_PER_DIGIT * nDigits]; // to store green values of each LED
-  _bArray = new byte[RGBDIGIT_SEGS_PER_DIGIT * nDigits]; // to store blue values of each LED
+  _rArray = new byte[segmentsPerDigit * nDigits]; // to store red values of each LED
+  _gArray = new byte[segmentsPerDigit * nDigits]; // to store green values of each LED
+  _bArray = new byte[segmentsPerDigit * nDigits]; // to store blue values of each LED
 }
 
 RGBDigit::~RGBDigit()
@@ -45,7 +45,7 @@ void RGBDigit::begin()
 
 void RGBDigit::clearAll()
 {
-  for (int segm = 0; segm < RGBDIGIT_SEGS_PER_DIGIT*_nDigits; segm++) {
+  for (int segm = 0; segm < _segmentsPerDigit*_nDigits; segm++) {
     _rArray[segm] = 0;
     _gArray[segm] = 0;
     _bArray[segm] = 0;
@@ -57,8 +57,8 @@ void RGBDigit::clearAll()
 void RGBDigit::setDigit(int number, int digit, byte red, byte green, byte blue)
 {
   if (number < 0 || number > 9) return;
-  for (int segm = RGBDIGIT_SEGS_PER_DIGIT*digit; segm < RGBDIGIT_SEGS_PER_DIGIT*digit + RGBDIGIT_SEGS_PER_DIGIT; segm++) {
-    if (_numberArray[segm % RGBDIGIT_SEGS_PER_DIGIT][number]) {
+  for (int segm = _segmentsPerDigit*digit; segm < _segmentsPerDigit*digit + _segmentsPerDigit; segm++) {
+    if (_numberArray[segm % _segmentsPerDigit][number]) {
       _rArray[segm] = red;
       _gArray[segm] = green;
       _bArray[segm] = blue;
@@ -122,8 +122,8 @@ void RGBDigit::setDigit(char character, int digit, byte red, byte green, byte bl
   if (character <= 'Z')
     character = character + 32;
 
-  for (int segm = RGBDIGIT_SEGS_PER_DIGIT*digit; segm < RGBDIGIT_SEGS_PER_DIGIT*digit + RGBDIGIT_SEGS_PER_DIGIT; segm++) {
-    if (_characterArray[segm % RGBDIGIT_SEGS_PER_DIGIT][character - 97]) {
+  for (int segm = _segmentsPerDigit*digit; segm < _segmentsPerDigit*digit + _segmentsPerDigit; segm++) {
+    if (_characterArray[segm % _segmentsPerDigit][character - 97]) {
       _rArray[segm] = red;
       _gArray[segm] = green;
       _bArray[segm] = blue;
@@ -139,8 +139,8 @@ void RGBDigit::setDigit(char character, int digit, byte red, byte green, byte bl
 }
 
 void RGBDigit::showSpecialCharacter(byte index, int digit, byte red, byte green, byte blue) {
-  for (int segm = RGBDIGIT_SEGS_PER_DIGIT*digit; segm < RGBDIGIT_SEGS_PER_DIGIT*digit + RGBDIGIT_SEGS_PER_DIGIT; segm++) {
-    if (_symbolArray[segm % RGBDIGIT_SEGS_PER_DIGIT][index]) {
+  for (int segm = _segmentsPerDigit*digit; segm < _segmentsPerDigit*digit + _segmentsPerDigit; segm++) {
+    if (_symbolArray[segm % _segmentsPerDigit][index]) {
       _rArray[segm] = red;
       _gArray[segm] = green;
       _bArray[segm] = blue;
@@ -157,7 +157,7 @@ void RGBDigit::showSpecialCharacter(byte index, int digit, byte red, byte green,
 
 void RGBDigit::clearDigit(int digit)
 {
-  for (int segm = RGBDIGIT_SEGS_PER_DIGIT*digit; segm < RGBDIGIT_SEGS_PER_DIGIT*digit + RGBDIGIT_SEGS_PER_DIGIT; segm++) {
+  for (int segm = _segmentsPerDigit*digit; segm < _segmentsPerDigit*digit + _segmentsPerDigit; segm++) {
     _rArray[segm] = 0;
     _gArray[segm] = 0;
     _bArray[segm] = 0;
@@ -169,8 +169,8 @@ void RGBDigit::clearDigit(int digit)
 void RGBDigit::showDot(int digit, byte red, byte green, byte blue)
 {
   //This only makes sense if there is a decimal point, wrapped in a conditional so does nothing if there is no dp.
-  if(RGBDIGIT_SEGS_PER_DIGIT>7) {
-    setPixelColor(RGBDIGIT_SEGS_PER_DIGIT*digit + (RGBDIGIT_SEGS_PER_DIGIT-1), red, green, blue);
+  if(_segmentsPerDigit>7) {
+    setPixelColor(_segmentsPerDigit*digit + (_segmentsPerDigit-1), red, green, blue);
     show();
   }
 }
@@ -178,15 +178,15 @@ void RGBDigit::showDot(int digit, byte red, byte green, byte blue)
 void RGBDigit::clearDot(int digit)
 {
   //This only makes sense if there is a decimal point, wrapped in a conditional so does nothing if there is no dp.
-  if(RGBDIGIT_SEGS_PER_DIGIT>7) {
-    setPixelColor(RGBDIGIT_SEGS_PER_DIGIT*digit + (RGBDIGIT_SEGS_PER_DIGIT-1), 0, 0, 0);
+  if(_segmentsPerDigit>7) {
+    setPixelColor(_segmentsPerDigit*digit + (_segmentsPerDigit-1), 0, 0, 0);
     show();
   }
 }
 
 void RGBDigit::segmentOn(int digit, byte segment, byte red, byte green, byte blue)
 {
-  int segm = RGBDIGIT_SEGS_PER_DIGIT*digit + segment;
+  int segm = _segmentsPerDigit*digit + segment;
   _rArray[segm] = red;
   _gArray[segm] = green;
   _bArray[segm] = blue;
@@ -196,7 +196,7 @@ void RGBDigit::segmentOn(int digit, byte segment, byte red, byte green, byte blu
 
 void RGBDigit::segmentOff(int digit, byte segment)
 {
-  int segm = RGBDIGIT_SEGS_PER_DIGIT*digit + segment;
+  int segm = _segmentsPerDigit*digit + segment;
   _rArray[segm] = 0;
   _gArray[segm] = 0;
   _bArray[segm] = 0;
@@ -206,14 +206,14 @@ void RGBDigit::segmentOff(int digit, byte segment)
 
 bool RGBDigit::isSegmentOn(int digit, byte segment)
 {
-  int segm = RGBDIGIT_SEGS_PER_DIGIT*digit + segment;
+  int segm = _segmentsPerDigit*digit + segment;
   return (_rArray[segm] > 0) || (_gArray[segm] > 0) || (_bArray[segm] > 0);
 }
 
 void RGBDigit::setColor(byte red, byte green, byte blue)
 {
-  for (int segm = 0; segm < RGBDIGIT_SEGS_PER_DIGIT*_nDigits; segm++) {
-    if ((segm - (RGBDIGIT_SEGS_PER_DIGIT-1)) % RGBDIGIT_SEGS_PER_DIGIT != 0) { // exclude dots
+  for (int segm = 0; segm < _segmentsPerDigit*_nDigits; segm++) {
+    if ((segm - (_segmentsPerDigit-1)) % _segmentsPerDigit != 0) { // exclude dots
       if ((_rArray[segm] != 0) || (_gArray[segm] != 0) || (_bArray[segm] != 0)) {
         _rArray[segm] = red;
         _gArray[segm] = green;
@@ -227,7 +227,7 @@ void RGBDigit::setColor(byte red, byte green, byte blue)
 
 void RGBDigit::setColor(int digit, byte red, byte green, byte blue)
 {
-  for (int segm = RGBDIGIT_SEGS_PER_DIGIT*digit; segm < RGBDIGIT_SEGS_PER_DIGIT*digit + (RGBDIGIT_SEGS_PER_DIGIT-1); segm++) {
+  for (int segm = _segmentsPerDigit*digit; segm < _segmentsPerDigit*digit + (_segmentsPerDigit-1); segm++) {
     if ((_rArray[segm] != 0) || (_gArray[segm] != 0) || (_bArray[segm] != 0)) {
       _rArray[segm] = red;
       _gArray[segm] = green;
@@ -246,4 +246,3 @@ void RGBDigit::setBrightness(byte brightness){
 byte RGBDigit::getBrightness() {
   return _brightness;
 }
-

--- a/RGBDigit.h
+++ b/RGBDigit.h
@@ -19,17 +19,13 @@
 #ifndef RGBDigit_h
 #define RGBDigit_h
 
-#ifndef RGBDIGIT_SEGS_PER_DIGIT
-    #define RGBDIGIT_SEGS_PER_DIGIT 8   //This can be 7 or 8 depending if the digit has a decimal point. This statement sets the default value of 8.
-#endif
-
 #include <Arduino.h>
 #include <Wire.h>
 #include <Adafruit_NeoPixel.h> //https://github.com/adafruit/Adafruit_NeoPixel
 
 class RGBDigit : public Adafruit_NeoPixel {
   public:
-    RGBDigit(int nDigits, int pin = 12, neoPixelType t=NEO_GRB + NEO_KHZ800);
+    RGBDigit(int nDigits, int pin = 12, neoPixelType t=NEO_GRB + NEO_KHZ800, int segmentsPerDigit = 8);
     ~RGBDigit();
     void begin();
     void clearAll();
@@ -48,6 +44,7 @@ class RGBDigit : public Adafruit_NeoPixel {
   private:
     byte _brightness;
     int _nDigits;
+    int _segmentsPerDigit;
     const bool _numberArray [8][10] = {
     // 0  1  2  3  4  5  6  7  8  9
       {1, 0, 1, 1, 0, 1, 1, 1, 1, 1}, //a             a


### PR DESCRIPTION
Dear @ralphcrutzen 

Many thanks for merging my previous PR (#5) I am very grateful.

Unfortunately there is something of a flaw with it.  I had made the changes and tested it using Eclipse (rather than the Arduino IDE) and the changes I made worked there.  However they don't work for a sketch compiled in the Arduino IDE as the compiler doesn't pass the` -D` parameter and so `#define`s made in the main sketch are not respected in the library code.

The only way round this was to make the `segmentsPerDigit` a parameter in the constructor as opposed to simply setting a `#define` in the sketch.

Apologies for the inconvenience of raising a second request - I should have tested the code in the Arduino IDE myself first.  I have raised the correction as quickly as I could - I hope you haven't had any complaints that the new functionality didn't work.

Kind Regards,

Gavin.